### PR TITLE
Generate class-based C++ from QASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qasm2cpp
 
-This repository contains a simple translator from [OpenQASM 3](https://openqasm.github.io/) to C++‑like code.  The `qasm2cpp.py` script reads an OpenQASM file and prints C++ source that relies on a minimal runtime provided in `qasm_common.hpp`.
+This repository contains a simple translator from [OpenQASM 3](https://openqasm.github.io/) to C++‑like code.  The `qasm2cpp.py` script reads an OpenQASM file and prints C++ source that relies on a minimal runtime provided in `qasm.hpp`.
 
 The folder `openqasm` is a copy of the official OpenQASM specification and examples for reference.  Only the translator script and the small header in this directory are required to use the converter.
 
@@ -23,7 +23,7 @@ python qasm2cpp.py < input.qasm > output.cpp
 python qasm2cpp.py input.qasm > output.cpp
 ```
 
-The generated code includes `qasm_common.hpp` and calls functions such as `qasm::cx`, `qasm::h` or `qasm::measure`.  These are declared in the header as stubs so the output can be compiled or further adapted.
+The generated code includes `qasm.hpp` and produces a small subclass of `qasm::qasm` with a `circuit` method.  Quantum operations are emitted using the fluent gate API, for example `h()(q);` or `(ctrl(2) * h())(q[0], q[1], q[2]);`.
 
 ## Example
 
@@ -36,11 +36,18 @@ python qasm2cpp.py openqasm/examples/adder.qasm > adder.cpp
 This produces a C++ file beginning with
 
 ```cpp
-#include <cstdio>
-#include <cmath>
-#include "qasm_common.hpp"
+#include "qasm.hpp"
+
+class userqasm : public qasm::qasm {
+public:
+    void circuit() {
+        using namespace qasm;
+        // ...
+    }
+};
+
+extern "C" qasm::qasm* constructor() { return new userqasm(); }
 ```
 
-which contains C++ functions for each gate and a `circuit` function inside the
-`qasm` namespace implementing the quantum program.
+The `circuit` method contains the translated quantum program.
 

--- a/tests/test_convert_examples.py
+++ b/tests/test_convert_examples.py
@@ -23,7 +23,7 @@ def test_qasm2cpp_conversion(qasm_file: Path):
         text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert "int circuit" in result.stdout
+    assert "class userqasm" in result.stdout
 
     out_file = OUTPUT_DIR / f"{qasm_file.stem}.cpp"
     out_file.write_text(result.stdout)

--- a/tests/test_qubit_declarations.py
+++ b/tests/test_qubit_declarations.py
@@ -13,13 +13,13 @@ def test_qubits_declared_at_top():
     )
     assert result.returncode == 0, result.stderr
     code = result.stdout
-    assert "int circuit" in code
+    assert "class userqasm" in code
 
     lines = code.splitlines()
-    start = next(i for i, line in enumerate(lines) if line.strip() == "int circuit(void) {") + 1
-    end = next(i for i, line in enumerate(lines) if line.strip() == "return 0;")
+    start = next(i for i, line in enumerate(lines) if line.strip() == "using namespace qasm;") + 1
+    end = next(i for i, line in enumerate(lines[start:], start) if line.strip() == "}")
     body = [line.strip() for line in lines[start:end] if line.strip()]
-    assert body[0].startswith("qasm::qubit")
-    assert body[1].startswith("qasm::qubit")
-    assert body[2] == "qasm::h(q);"
-    assert body[3] == "qasm::x(r);"
+    assert body[0].startswith("qubit")
+    assert body[1].startswith("qubit")
+    assert body[2] == "h()(q);"
+    assert body[3] == "x()(r);"


### PR DESCRIPTION
## Summary
- emit C++ that subclasses `qasm::qasm` and defines `userqasm::circuit`
- switch gate emission to fluent functor calls and allocate qubits via `qalloc`
- document new output format and adjust tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f68e7bc38832ba67f54e3eead4981