### PR TITLE
Respect original declaration order and handle def/extern/gate

### DIFF
--- a/tests/def_extern.qasm
+++ b/tests/def_extern.qasm
@@ -1,0 +1,8 @@
+OPENQASM 3;
+extern foo(float);
+def bar(float x) {
+    foo(x);
+}
+qubit q;
+bar(0.5);
+

--- a/tests/gate_definition.qasm
+++ b/tests/gate_definition.qasm
@@ -1,0 +1,7 @@
+OPENQASM 3;
+gate foo q {
+    h q;
+}
+qubit q;
+h q;
+

--- a/tests/test_def_and_extern.py
+++ b/tests/test_def_and_extern.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_def_as_method_and_extern_global():
+    qasm_file = Path(__file__).with_name("def_extern.qasm")
+    result = subprocess.run(
+        [sys.executable, "qasm2cpp.py", str(qasm_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    code = result.stdout
+
+    lines = code.splitlines()
+    class_idx = next(i for i, line in enumerate(lines) if line.strip().startswith("class userqasm"))
+
+    extern_lines = [line.strip() for line in lines[:class_idx] if line.strip()]
+    assert any(line.startswith("extern void foo") for line in extern_lines)
+
+    circuit_idx = next(i for i, line in enumerate(lines) if line.strip().startswith("void circuit"))
+    method_lines = []
+    for line in lines[class_idx + 1 : circuit_idx]:
+        stripped = line.strip()
+        if stripped and stripped not in {"public:", "{"}:
+            method_lines.append(stripped)
+    assert method_lines[0].startswith("void bar")
+
+    start = next(
+        i for i, line in enumerate(lines[circuit_idx:], circuit_idx) if line.strip() == "using namespace qasm;"
+    ) + 1
+    end = next(i for i, line in enumerate(lines[start:], start) if line.strip() == "}")
+    body = [line.strip() for line in lines[start:end] if line.strip()]
+    assert body[0].startswith("qubit")
+    assert body[1] == "bar(0.5);"
+

--- a/tests/test_gate_definition.py
+++ b/tests/test_gate_definition.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_gate_definition_comment():
+    qasm_file = Path(__file__).with_name("gate_definition.qasm")
+    result = subprocess.run(
+        [sys.executable, "qasm2cpp.py", str(qasm_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    code = result.stdout
+    assert "/* gate foo not supported */" in code
+

--- a/tests/test_qubit_declarations.py
+++ b/tests/test_qubit_declarations.py
@@ -20,6 +20,6 @@ def test_qubits_declared_at_top():
     end = next(i for i, line in enumerate(lines[start:], start) if line.strip() == "}")
     body = [line.strip() for line in lines[start:end] if line.strip()]
     assert body[0].startswith("qubit")
-    assert body[1].startswith("qubit")
-    assert body[2] == "h()(q);"
+    assert body[1] == "h()(q);"
+    assert body[2].startswith("qubit")
     assert body[3] == "x()(r);"


### PR DESCRIPTION
## Summary
- Keep qubit declarations in their original order rather than hoisting
- Emit `def` as methods on the generated `userqasm` class and place `extern` declarations at global scope
- Mark `gate` definitions as unsupported with a comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f7025de60832badb0513b793cfb75