### PR TITLE
Use clalloc for classical bit registers

### DIFF
--- a/examples/adder.cpp
+++ b/examples/adder.cpp
@@ -13,7 +13,7 @@ public:
         qubits a = qalloc(4);
         qubits b = qalloc(4);
         qubits cout = qalloc(1);
-        bit<5> ans;
+        bit ans = clalloc(5);
         uint<4> a_in = 1;
         uint<4> b_in = 15;
         reset(cin);

--- a/examples/ghz.cpp
+++ b/examples/ghz.cpp
@@ -8,7 +8,7 @@ public:
         using namespace qasm;
         
         qubits q = qalloc(14);
-        bit<14> cl;
+        bit cl = clalloc(14);
         h()(q);
         for (unsigned int i : slice(0, 13)) {
             x()(q[0], q[i]);

--- a/examples/qft.cpp
+++ b/examples/qft.cpp
@@ -8,7 +8,7 @@ public:
         using namespace qasm;
         
         qubits q = qalloc(4);
-        bit<4> c;
+        bit c = clalloc(4);
         reset(q);
         x()(q[0]);
         x()(q[2]);

--- a/examples/vqe.cpp
+++ b/examples/vqe.cpp
@@ -79,7 +79,8 @@ public:
         float_<prec> energy;
         uint<prec> npaulis = get_npaulis();
         for (int t : slice(0, npaulis - 1)) {
-            bit<2 * n> spec = get_pauli(t);
+            bit spec = clalloc(2 * n);
+            spec = get_pauli(t);
             uint<prec> counts;
             counts = counts_for_term(spec, q);
             energy = update_energy(t, counts, energy);


### PR DESCRIPTION
## Summary
- allocate bit arrays with `clalloc` instead of template types
- regenerate example outputs to match new bit allocation semantics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68944399f1bc832b9df869aff78319c2